### PR TITLE
Use execFile instead of exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,6 @@ diskusage('/home/me', function(err, usage) {
 
 ```
 
-## Posix notes
-Filenames with `"` inside will be rejected with an explicit error.
-Bash substitution works, so for example `diskusage('$HOME', ...)` will show a diskusage for the user's home dir.
-**It means that passing a raw user input to `diskusage()` can lead to arbitrary code execution.**
-
 ## Commands
 ```
 npm run test

--- a/lib/posix.js
+++ b/lib/posix.js
@@ -1,14 +1,10 @@
 'use strict';
 
-var exec = require('child_process').exec;
+var execFile = require('child_process').execFile;
 var isDigits = require('./utils').isDigits;
 
 function diskusage(path, cb) {
-    if (path.indexOf('"') !== -1) {
-        return cb(new Error('Paths with double quotes are not supported yet'));
-    }
-
-    exec('df -k "' + path + '"', function(err, stdout) {
+    execFile('df', ['-k', path], function(err, stdout) {
         if (err) {
             return cb(err);
         }


### PR DESCRIPTION
To prevent security risk & improve performance (do not rely on a shell)