### PR TITLE
add windows exec option

### DIFF
--- a/lib/win32.js
+++ b/lib/win32.js
@@ -5,7 +5,7 @@ var Path = require('path');
 var utils = require('./utils')
 
 function diskusage(path, cb) {
-    exec('WMIC LOGICALDISK GET Name,Size,FreeSpace', function(err, stdout) {
+    exec('WMIC LOGICALDISK GET Name,Size,FreeSpace', { windowsHide: true }, function(err, stdout) {
         if (err) {
             return cb(err);
         }


### PR DESCRIPTION
I recently made a binary code executable of my node application using your wonderful diskusage module on windows and ran it with pm2.

However, I found a phenomenon where the cmd is constantly flashing.

I added the { windowsHide: true } option and the problem was no longer found.

I would be grateful if you could check it.